### PR TITLE
Added support for multiple objectClasses to be set on the EntityMap.

### DIFF
--- a/lib/SlapOM/EntityMap.php
+++ b/lib/SlapOM/EntityMap.php
@@ -121,7 +121,12 @@ abstract class EntityMap
 
     protected function getObjectClassFilter()
     {
-      return sprintf("(objectClass=%s)", $this->ldap_object_class);
+        if (is_string($this->ldap_object_class)) {
+            return sprintf("(objectClass=%s)", $this->ldap_object_class);
+        }
+        elseif (is_array($this->ldap_object_class)) {
+            return '(objectClass=' . implode(')(objectClass=', $this->ldap_object_class) . ')';
+        }
     }
 
     protected function checkDn($dn)


### PR DESCRIPTION
Currently, a user extends EntityMap and sets, amongst other things, $this->ldap_object_class which expects a string. I am not sure how common it is but in our active directory we have multiple objectClasses and when it came to adding a new user, I needed to set a number of objectClasses for the operation to complete successfully.

This pull request preserves existing functionality in that a user can still set $this->ldap_object_class with a string value but also allows a user to set an array of objectClasses if they so wish.
